### PR TITLE
fix: Rename "last updated" to "last retrieved"

### DIFF
--- a/data_registry/models.py
+++ b/data_registry/models.py
@@ -104,7 +104,7 @@ class Collection(Model):
     description_long = MarkdownxField(blank=True,
                                       help_text="The remaining paragraphs of the description of the publication, as "
                                                 "Markdown text, which will appear under \"Show more\".")
-    last_update = DateField(blank=True, null=True, verbose_name="last updated",
+    last_update = DateField(blank=True, null=True, verbose_name="last retrieved",
                             help_text="The date on which the most recent 'scrape' job task completed.")
 
     license_custom = ForeignKey("License", related_name="collection", on_delete=CASCADE, blank=True, null=True,

--- a/data_registry/templates/detail.html
+++ b/data_registry/templates/detail.html
@@ -78,7 +78,7 @@
                     <span class="value" v-if="activeJob">[[ activeJob.date_from | moment("MMM YYYY") ]] - [[ activeJob.date_to | moment("MMM YYYY") ]]</span>
                 </div>
                 <div>
-                    <span class="label">{% translate "Last updated:" %}</span>
+                    <span class="label">{% translate "Last retrieved:" %}</span>
                     <span class="value">[[ data.last_update | moment("D MMM YYYY") ]]</span>
                 </div>
                 <div>

--- a/data_registry/templates/search.html
+++ b/data_registry/templates/search.html
@@ -178,7 +178,7 @@
                                     </span>
                                 </div>
                                 <div class="mb-2">
-                                    <span class="label">{% translate "Last updated:" %}</span>
+                                    <span class="label">{% translate "Last retrieved:" %}</span>
                                     <span class="value" v-if="c.last_update">[[ c.last_update | moment("MMM YYYY") ]]</span>
                                 </div>
                             </div>


### PR DESCRIPTION
Related: #21

I haven't generated the migration yet. Just pushing a git stash that I had.