### PR TITLE
Flattener fixes

### DIFF
--- a/data_registry/models.py
+++ b/data_registry/models.py
@@ -90,7 +90,7 @@ class Job(models.Model):
         return dt.strftime("%d-%b-%y") if dt else ""
 
     def get_max_number_of_rows(self):
-        count_columns = filter(lambda name: '_count' in name, dir(self))
+        count_columns = filter(lambda name: "_count" in name, dir(self))
         return max([self.__getattribute__(column) for column in count_columns])
 
 

--- a/data_registry/models.py
+++ b/data_registry/models.py
@@ -89,6 +89,10 @@ class Job(models.Model):
     def format_datetime(self, dt):
         return dt.strftime("%d-%b-%y") if dt else ""
 
+    def get_max_number_of_rows(self):
+        count_columns = filter(lambda name: '_count' in name, dir(self))
+        return max([self.__getattribute__(column) for column in count_columns])
+
 
 class CollectionQuerySet(models.QuerySet):
     def visible(self):

--- a/data_registry/models.py
+++ b/data_registry/models.py
@@ -89,9 +89,10 @@ class Job(models.Model):
     def format_datetime(self, dt):
         return dt.strftime("%d-%b-%y") if dt else ""
 
-    def get_max_number_of_rows(self):
-        count_columns = filter(lambda name: "_count" in name, dir(self))
-        return max([self.__getattribute__(column) for column in count_columns])
+    def get_max_rows_lower_bound(self):
+        return max(
+            getattr(self, field.attname) or 0 for field in Job._meta.get_fields() if field.name.endswith("_count")
+        )
 
 
 class CollectionQuerySet(models.QuerySet):

--- a/exporter/util.py
+++ b/exporter/util.py
@@ -126,7 +126,7 @@ class Export:
             if suffix not in files:
                 continue
             prefix = path.name[:4]  # year or "full"
-            if prefix.isdigit():
+            if prefix.isdigit() and "_" not in path.name:  # don't return month files
                 files[suffix]["years"].add(int(prefix))
             elif prefix == "full":
                 files[suffix]["full"] = True


### PR DESCRIPTION
ref #244 

I also added an additional check for not returning month files as available files at all, for now, otherwise, if there is at least one xlsx or CSV month file, that will incorrectly be shown in the front end as a year file.