### PR TITLE
fix: download_export was not checking the correct lockfile.

### DIFF
--- a/data_registry/process_manager/task/exporter.py
+++ b/data_registry/process_manager/task/exporter.py
@@ -1,5 +1,5 @@
 from data_registry.models import Task
-from exporter.util import Export, publish
+from exporter.util import Export, TaskStatus, publish
 
 
 class Exporter:
@@ -11,12 +11,12 @@ class Exporter:
         publish({"collection_id": self.collection_id, "job_id": self.job.id}, "exporter_init")
 
     def get_status(self):
-        status = Export(self.job.id).status
-        if status == "WAITING":
+        status = Export(self.job.id, "full.jsonl.gz").status
+        if status == TaskStatus.WAITING:
             return Task.Status.WAITING
-        if status == "RUNNING":
+        if status == TaskStatus.RUNNING:
             return Task.Status.RUNNING
-        if status == "COMPLETED":
+        if status == TaskStatus.COMPLETED:
             return Task.Status.COMPLETED
 
     def wipe(self):

--- a/data_registry/process_manager/task/exporter.py
+++ b/data_registry/process_manager/task/exporter.py
@@ -11,7 +11,7 @@ class Exporter:
         publish({"collection_id": self.collection_id, "job_id": self.job.id}, "exporter_init")
 
     def get_status(self):
-        status = Export(self.job.id, "full.jsonl.gz").status
+        status = Export(self.job.id, basename="full.jsonl.gz").status
         if status == TaskStatus.WAITING:
             return Task.Status.WAITING
         if status == TaskStatus.RUNNING:

--- a/data_registry/process_manager/task/flattener.py
+++ b/data_registry/process_manager/task/flattener.py
@@ -1,5 +1,5 @@
 from data_registry.models import Task
-from exporter.util import Export, publish
+from exporter.util import Export, TaskStatus, publish
 
 
 class Flattener:
@@ -10,12 +10,12 @@ class Flattener:
         publish({"job_id": self.job.id}, "flattener_init")
 
     def get_status(self):
-        status = Export(self.job.id, export_type="flat").status
-        if status == "WAITING":
+        status = Export(self.job.id, "full.csv.tar.gz").status
+        if status == TaskStatus.WAITING:
             return Task.Status.WAITING
-        if status == "RUNNING":
+        if status == TaskStatus.RUNNING:
             return Task.Status.RUNNING
-        if status == "COMPLETED":
+        if status == TaskStatus.COMPLETED:
             return Task.Status.COMPLETED
 
     def wipe(self):

--- a/data_registry/process_manager/task/flattener.py
+++ b/data_registry/process_manager/task/flattener.py
@@ -10,7 +10,7 @@ class Flattener:
         publish({"job_id": self.job.id}, "flattener_init")
 
     def get_status(self):
-        status = Export(self.job.id, "full.csv.tar.gz").status
+        status = Export(self.job.id, basename="full.csv.tar.gz").status
         if status == TaskStatus.WAITING:
             return Task.Status.WAITING
         if status == TaskStatus.RUNNING:

--- a/exporter/management/commands/exporter.py
+++ b/exporter/management/commands/exporter.py
@@ -30,7 +30,7 @@ def callback(state, channel, method, properties, input_message):
     collection_id = input_message.get("collection_id")
     job_id = input_message.get("job_id")
 
-    export = Export(job_id, "full.json.gz")
+    export = Export(job_id, basename="full.json.gz")
     dump_file = export.directory / "full.jsonl"
 
     try:

--- a/exporter/management/commands/exporter.py
+++ b/exporter/management/commands/exporter.py
@@ -30,7 +30,7 @@ def callback(state, channel, method, properties, input_message):
     collection_id = input_message.get("collection_id")
     job_id = input_message.get("job_id")
 
-    export = Export(job_id)
+    export = Export(job_id, "full.json.gz")
     dump_file = export.directory / "full.jsonl"
 
     try:

--- a/exporter/management/commands/flattener.py
+++ b/exporter/management/commands/flattener.py
@@ -54,7 +54,7 @@ def process_file(job_id, file_path):
     file_name = os.path.basename(file_path)
     stem = file_name[:-9]  # remove .jsonl.gz
 
-    export = Export(job_id, f"{stem}.csv.tar.gz")
+    export = Export(job_id, basename=f"{stem}.csv.tar.gz")
 
     csv_path = export.directory / f"{stem}.csv.tar.gz"
     xlsx_path = export.directory / f"{stem}.xlsx"

--- a/exporter/management/commands/flattener.py
+++ b/exporter/management/commands/flattener.py
@@ -43,22 +43,21 @@ def callback(state, channel, method, properties, input_message):
 
 
 def publish_file(job_id):
-    export = Export(job_id, export_type="flat")
+    export = Export(job_id)
     for entry in os.scandir(export.directory):
-        if not entry.name.endswith(".jsonl.gz") or "_" in entry.name:  # don't process months at the moment
+        if not entry.name.endswith(".jsonl.gz") or "_" in entry.name:  # don't process months files
             continue
         publish({"job_id": job_id, "file_path": entry.path}, "flattener_file")
 
 
 def process_file(job_id, file_path):
     file_name = os.path.basename(file_path)
+    stem = file_name[:-9]  # remove .jsonl.gz
 
-    export = Export(job_id, export_type="flat", lockfile_suffix=file_name)
+    export = Export(job_id, f"{stem}.csv.tar.gz")
 
-    final_path_prefix = file_path[:-9]  # remove .jsonl.gz
-
-    csv_path = f"{final_path_prefix}.csv.tar.gz"
-    xlsx_path = f"{final_path_prefix}.xlsx"
+    csv_path = export.directory / f"{stem}.csv.tar.gz"
+    xlsx_path = export.directory / f"{stem}.xlsx"
     csv_exists = os.path.isfile(csv_path)
     xlsx_exists = os.path.isfile(xlsx_path)
 

--- a/exporter/views.py
+++ b/exporter/views.py
@@ -27,7 +27,7 @@ def download_export(request):
         basename = f"{year}.{suffix}"
         filename = f"{spider}_{year}.{suffix}"
 
-    export = Export(job_id, basename)
+    export = Export(job_id, basename=basename)
 
     if export.status != TaskStatus.COMPLETED:
         return HttpResponseNotFound("File not found")


### PR DESCRIPTION
- Explicitly set the name of the export file when checking status and creating locks
- Add a TaskStatus class to avoid using strings as constants
- Add Export.__repr__ because logger isn't calling __str__, apparently
