### PR TITLE
feat: add datasets-metadata endpoint

### DIFF
--- a/data_registry/urls.py
+++ b/data_registry/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
     path("search/", views.search, name="search"),
     path("publication/<int:id>", views.detail, name="detail"),
     path("publication/<int:id>/download", views.download_export, name="download"),
-    path("datasets-metadata", views.datasets_metadata, name="datasets_metadata"),
+    path("publications.json", views.publications_api, name="publications_api"),
     # Uncomment after re-integrating Spoonbill.
     # path("excel-data/<int:job_id>/<str:job_range>", views.excel_data, name="excel-data"),
     # path("excel-data/<int:job_id>", views.excel_data, name="all-excel-data"),

--- a/data_registry/urls.py
+++ b/data_registry/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path("search/", views.search, name="search"),
     path("publication/<int:id>", views.detail, name="detail"),
     path("publication/<int:id>/download", views.download_export, name="download"),
+    path("datasets-metadata", views.datasets_metadata, name="datasets_metadata"),
     # Uncomment after re-integrating Spoonbill.
     # path("excel-data/<int:job_id>/<str:job_range>", views.excel_data, name="excel-data"),
     # path("excel-data/<int:job_id>", views.excel_data, name="all-excel-data"),

--- a/data_registry/views.py
+++ b/data_registry/views.py
@@ -200,22 +200,26 @@ def download_export(request, id):
     )
 
 
-def datasets_metadata(request):
+def publications_api(request):
     return JsonResponse(
         list(
-            Collection.objects.filter(public=True, job__active=True)
+            Collection.objects.visible()
             .values(
+                # Identification
                 "id",
                 "title",
                 "country",
+                # Accrual periodicity
                 "last_retrieved",
                 "retrieval_frequency",
-                "source_id",
-                "frozen",
-                "language",
-                "source_url",
                 "update_frequency",
+                "frozen",
+                # Provenance
+                "source_id",
+                "source_url",
+                # Other details
                 "region",
+                "language",
             )
             .annotate(data_from=F("job__date_from"), data_to=F("job__date_to"))
         ),

--- a/data_registry/views.py
+++ b/data_registry/views.py
@@ -10,7 +10,7 @@ from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.postgres.aggregates import ArrayAgg
-from django.db.models import Count, OuterRef, Q, Subquery
+from django.db.models import Count, F, OuterRef, Q, Subquery
 from django.db.models.functions import Substr
 from django.http.response import FileResponse, HttpResponse, HttpResponseBadRequest, HttpResponseNotFound, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -197,6 +197,29 @@ def download_export(request, id):
         # Set Content-Encoding to skip GZipMiddleware. (ContentEncodingMiddleware removes the empty header.)
         # https://docs.djangoproject.com/en/4.2/ref/middleware/#module-django.middleware.gzip
         headers={"Content-Encoding": ""},
+    )
+
+
+def datasets_metadata(request):
+    return JsonResponse(
+        list(
+            Collection.objects.filter(public=True, job__active=True)
+            .values(
+                "id",
+                "title",
+                "country",
+                "last_retrieved",
+                "retrieval_frequency",
+                "source_id",
+                "frozen",
+                "language",
+                "source_url",
+                "update_frequency",
+                "region",
+            )
+            .annotate(data_from=F("job__date_from"), data_to=F("job__date_to"))
+        ),
+        safe=False,
     )
 
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,7 +10,7 @@ asgiref==3.7.2
     #   django
 backports-entry-points-selectable==1.2.0
     # via virtualenv
-black==21.12b0
+black==24.2.0
     # via -r requirements_dev.in
 build==0.10.0
     # via pip-tools
@@ -60,9 +60,7 @@ flake8==3.8.4
 flatterer==0.19.15
     # via -r requirements.txt
 gunicorn[setproctitle]==20.1.0
-    # via
-    #   -r requirements.txt
-    #   gunicorn
+    # via -r requirements.txt
 identify==2.3.5
     # via pre-commit
 idna==2.10
@@ -101,7 +99,9 @@ orjson==3.9.1
     #   flatterer
     #   yapw
 packaging==23.1
-    # via build
+    # via
+    #   black
+    #   build
 pandas==1.5.0
     # via
     #   -r requirements.txt
@@ -163,12 +163,9 @@ sqlparse==0.4.4
     # via
     #   -r requirements.txt
     #   django
-tomli==1.2.2
-    # via black
 typing-extensions==4.7.1
     # via
     #   -r requirements.txt
-    #   black
     #   dj-database-url
     #   django-modeltranslation
 urllib3==2.0.7
@@ -181,9 +178,7 @@ virtualenv==20.10.0
 wheel==0.38.4
     # via pip-tools
 yapw[perf]==0.1.4
-    # via
-    #   -r requirements.txt
-    #   yapw
+    # via -r requirements.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/tests/data_registry/test_views.py
+++ b/tests/data_registry/test_views.py
@@ -33,19 +33,23 @@ class ViewsTests(TestCase):
 
     def test_publications_api(self):
         expected_response = {
+            # Identification
             "id": self.collection.id,
             "title": self.collection.title_en,
-            "source_id": self.collection.source_id,
-            "update_frequency": Collection.UpdateFrequency.UNKNOWN.name,
             "country": "",
-            "data_to": None,
-            "data_from": None,
-            "frozen": False,
-            "language": "",
+            # Accrual periodicity
             "last_retrieved": None,
             "retrieval_frequency": "",
+            "update_frequency": Collection.UpdateFrequency.UNKNOWN.name,
+            "frozen": False,
+            # Provenance
+            "source_id": self.collection.source_id,
             "source_url": "",
+            # Other details
             "region": "",
+            "language": "",
+            "date_to": None,
+            "date_from": None,
         }
         response = Client().get("/en/publications.json")
         self.assertEqual(response.status_code, 200)

--- a/tests/data_registry/test_views.py
+++ b/tests/data_registry/test_views.py
@@ -20,11 +20,6 @@ class ViewsTests(TestCase):
             active=True,
         )
 
-        Collection.objects.create(
-            title="Non public collection",
-            public=False,
-        )
-
     @patch("exporter.util.Export.get_files")
     def test_detail(self, get_files):
         get_files.return_value = {"jsonl": {"by_year": [{"year": 2022, "size": 1}]}}
@@ -37,7 +32,6 @@ class ViewsTests(TestCase):
         self.assertContains(response, f"""<a href="{url}" rel="nofollow" download>2022</a>""", html=True)
 
     def test_publications_api(self):
-        response = Client().get("/en/publications.json")
         expected_response = {
             "id": self.collection.id,
             "title": self.collection.title_en,
@@ -53,9 +47,23 @@ class ViewsTests(TestCase):
             "source_url": "",
             "region": "",
         }
+        response = Client().get("/en/publications.json")
         self.assertEqual(response.status_code, 200)
-        self.assertJSONEqual(str(response.content, encoding="utf8"), [expected_response])
-
+        self.assertEqual(response.json(), [expected_response])
         response = Client().get("/es/publications.json")
+        self.assertEqual(response.status_code, 200)
         expected_response["title"] = self.collection.title_es
-        self.assertJSONEqual(str(response.content, encoding="utf8"), [expected_response])
+        self.assertEqual(response.json(), [expected_response])
+        self.collection.delete()
+        self.job.delete()
+
+        for public, active_job in ((False, True), (True, False), (False, False)):
+            with self.subTest(public=public, active_job=active_job):
+                collection = Collection.objects.create(title="Test", public=public)
+                if active_job:
+                    collection.job.create(
+                        active=True,
+                    )
+                response = Client().get("/es/publications.json")
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json(), [])

--- a/tests/data_registry/test_views.py
+++ b/tests/data_registry/test_views.py
@@ -1,23 +1,40 @@
+import datetime
 from unittest.mock import patch
 
 from django.test import Client, TestCase, override_settings
 
-from data_registry.models import Collection
+from data_registry import models
 
 
 @override_settings(STORAGES={"staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"}})
 class ViewsTests(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.collection = Collection.objects.create(
+        cls.collection = models.Collection.objects.create(
+            public=True,
+            # Identification
             title="Dirección Nacional de Contrataciones Públicas (DNCP)",
             title_en="National Directorate of Public Procurement (DNCP)",
             title_es="Dirección Nacional de Contrataciones Públicas (DNCP)",
+            country="Paraguay",
+            country_en="Paraguay (EN)",
+            country_es="Paraguay (ES)",
+            # Accrual periodicity
+            last_retrieved=datetime.date(2001, 2, 3),
+            retrieval_frequency=models.Collection.RetrievalFrequency.MONTHLY,
+            # Provenance
             source_id="paraguay_dncp_records",
-            public=True,
+            source_url="https://contrataciones.gov.py/datos/api/v3/doc/",
+            # Other details
+            region=models.Collection.Region.LAC,
+            language="Untranslated",
+            language_en="Spanish",
+            language_es="Español",
         )
         cls.job = cls.collection.job.create(
             active=True,
+            date_from=datetime.date(2010, 2, 1),
+            date_to=datetime.date(2023, 9, 30),
         )
 
     @patch("exporter.util.Export.get_files")
@@ -32,42 +49,54 @@ class ViewsTests(TestCase):
         self.assertContains(response, f"""<a href="{url}" rel="nofollow" download>2022</a>""", html=True)
 
     def test_publications_api(self):
-        expected_response = {
+        extra_job = self.collection.job.create(active=True)
+
+        en_response = Client().get("/en/publications.json")
+        es_response = Client().get("/es/publications.json")
+
+        extra_job.delete()
+
+        expected = {
             # Identification
             "id": self.collection.id,
-            "title": self.collection.title_en,
-            "country": "",
+            "title": "National Directorate of Public Procurement (DNCP)",
+            "country": "Paraguay (EN)",
             # Accrual periodicity
-            "last_retrieved": None,
-            "retrieval_frequency": "",
-            "update_frequency": Collection.UpdateFrequency.UNKNOWN.name,
+            "last_retrieved": "2001-02-03",
+            "retrieval_frequency": "MONTHLY",
+            "update_frequency": "UNKNOWN",
             "frozen": False,
             # Provenance
-            "source_id": self.collection.source_id,
-            "source_url": "",
+            "source_id": "paraguay_dncp_records",
+            "source_url": "https://contrataciones.gov.py/datos/api/v3/doc/",
             # Other details
-            "region": "",
-            "language": "",
-            "date_to": None,
-            "date_from": None,
+            "region": "LAC",
+            "language": "Spanish",
+            "date_from": "2010-02-01",
+            "date_to": "2023-09-30",
         }
-        response = Client().get("/en/publications.json")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [expected_response])
-        response = Client().get("/es/publications.json")
-        self.assertEqual(response.status_code, 200)
-        expected_response["title"] = self.collection.title_es
-        self.assertEqual(response.json(), [expected_response])
-        self.collection.delete()
-        self.job.delete()
+
+        self.assertEqual(en_response.status_code, 200)
+        self.assertEqual(en_response.json(), [expected])
+
+        expected["title"] = "Dirección Nacional de Contrataciones Públicas (DNCP)"
+        expected["country"] = "Paraguay (ES)"
+        expected["language"] = "Español"
+
+        self.assertEqual(es_response.status_code, 200)
+        self.assertEqual(es_response.json(), [expected])
 
         for public, active_job in ((False, True), (True, False), (False, False)):
             with self.subTest(public=public, active_job=active_job):
-                collection = Collection.objects.create(title="Test", public=public)
-                if active_job:
-                    collection.job.create(
-                        active=True,
-                    )
+                collection = models.Collection.objects.create(public=public)
+                job1 = collection.job.create(active=active_job)
+                job2 = collection.job.create(active=active_job)
+
                 response = Client().get("/es/publications.json")
+
+                collection.delete()
+                job1.delete()
+                job2.delete()
+
                 self.assertEqual(response.status_code, 200)
-                self.assertEqual(response.json(), [])
+                self.assertEqual(response.json(), [expected])

--- a/tests/data_registry/test_views.py
+++ b/tests/data_registry/test_views.py
@@ -13,10 +13,10 @@ class ViewsTests(TestCase):
         cls.collection = models.Collection.objects.create(
             public=True,
             # Identification
-            title="Dirección Nacional de Contrataciones Públicas (DNCP)",
+            title="Ignore",
             title_en="National Directorate of Public Procurement (DNCP)",
             title_es="Dirección Nacional de Contrataciones Públicas (DNCP)",
-            country="Paraguay",
+            country="Ignore",
             country_en="Paraguay (EN)",
             country_es="Paraguay (ES)",
             # Accrual periodicity
@@ -27,7 +27,7 @@ class ViewsTests(TestCase):
             source_url="https://contrataciones.gov.py/datos/api/v3/doc/",
             # Other details
             region=models.Collection.Region.LAC,
-            language="Untranslated",
+            language="Ignore",
             language_en="Spanish",
             language_es="Español",
         )

--- a/tests/data_registry/test_views.py
+++ b/tests/data_registry/test_views.py
@@ -11,11 +11,18 @@ class ViewsTests(TestCase):
     def setUpTestData(cls):
         cls.collection = Collection.objects.create(
             title="Dirección Nacional de Contrataciones Públicas (DNCP)",
+            title_en="National Directorate of Public Procurement (DNCP)",
+            title_es="Dirección Nacional de Contrataciones Públicas (DNCP)",
             source_id="paraguay_dncp_records",
             public=True,
         )
         cls.job = cls.collection.job.create(
             active=True,
+        )
+
+        Collection.objects.create(
+            title="Non public collection",
+            public=False,
         )
 
     @patch("exporter.util.Export.get_files")
@@ -28,3 +35,27 @@ class ViewsTests(TestCase):
 
         self.assertTemplateUsed("detail.html")
         self.assertContains(response, f"""<a href="{url}" rel="nofollow" download>2022</a>""", html=True)
+
+    def test_publications_api(self):
+        response = Client().get("/en/publications.json")
+        expected_response = {
+            "id": self.collection.id,
+            "title": self.collection.title_en,
+            "source_id": self.collection.source_id,
+            "update_frequency": Collection.UpdateFrequency.UNKNOWN.name,
+            "country": "",
+            "data_to": None,
+            "data_from": None,
+            "frozen": False,
+            "language": "",
+            "last_retrieved": None,
+            "retrieval_frequency": "",
+            "source_url": "",
+            "region": "",
+        }
+        self.assertEqual(response.status_code, 200)
+        self.assertJSONEqual(str(response.content, encoding="utf8"), [expected_response])
+
+        response = Client().get("/es/publications.json")
+        expected_response["title"] = self.collection.title_es
+        self.assertJSONEqual(str(response.content, encoding="utf8"), [expected_response])


### PR DESCRIPTION
ref #268 
@jpmckinney I'm prioritizing this one so that we can use this endpoint as part of our "download Data from the Registry" notebooks and download the data more easily (without having to copy and paste the URL from the registry or query the database for downloading all the datasets)

I've added the columns we need to automatically download the JSON files, plus others mentioned in the issue. But happy to add more if needed.